### PR TITLE
Modeling issue 28 train test split

### DIFF
--- a/utils/loading.py
+++ b/utils/loading.py
@@ -56,7 +56,7 @@ def load_cv_split():
     return df_cv_split
 
 
-def load_extended_posts(split:str=None ):
+def load_extended_posts(split:str=None, label:str=None):
     '''
     Load post table extended by annotations and staff.
     Args:
@@ -92,4 +92,6 @@ def load_extended_posts(split:str=None ):
     article_features = article_features.add_prefix('article_')
     df = df.merge(article_features, how='left', left_on='id_article', right_on='article_id_article').drop('article_id_article', axis=1)
     
+    if label:
+        df = df.dropna(subset=[label])
     return df

--- a/utils/train_test_val_split.py
+++ b/utils/train_test_val_split.py
@@ -1,5 +1,8 @@
+import pandas as pd
+from sklearn.model_selection import train_test_split
+
 from utils import loading, feature_engineering
-from sklearn.model_selection import train_test_split 
+ 
 
 def create_splits():
     """
@@ -12,25 +15,29 @@ def create_splits():
     RSEED=42
     df_posts = loading.load_extended_posts() 
     df_posts = feature_engineering.add_column_ann_round(df_posts)
-    df_ann2 = df_posts.query("ann_round == 2")
-    df_ann3 = df_posts.query("ann_round == 3")
-    features_strat = ['label_discriminating', 'label_inappropriate','label_sentimentpositive']
     
-    ann2_train, ann2_test = train_test_split(df_ann2, stratify=df_ann2[features_strat],random_state=RSEED, test_size=250)
+    # The first round of EDA showed, that only posts annotated in round 2 represent the population. 
+    # Posts annotated in round 3 will only be used for the labels "possiblyFeedback" and 
+    # "personalStories" (i.e. NaN in any of the other lables) and only in the training set.
+    df_ann2 = df_posts.query("ann_round == 2")
+    df_ann3_feedback_stories = df_posts.query("ann_round == 3 and label_offtopic != label_offtopic")
+    
+    # Due to a small dataset (1,000 posts) we want to keep 100 observations for test and validation split each
+    # We stratify by labels, that are least frequent in our 1,000 observations
+    features_strat = ['label_discriminating', 'label_possiblyfeedback', 'label_personalstories', 'label_sentimentpositive']
+    ann2_train, ann2_test = train_test_split(df_ann2, stratify=df_ann2[features_strat],random_state=RSEED, test_size=100)
     ann2_train, ann2_val = train_test_split(ann2_train, stratify=ann2_train[features_strat],random_state=RSEED, test_size=100)
 
-    #ann3_train, ann3_test = train_test_split(df_ann3, stratify=df_ann3[features_strat],random_state=RSEED, test_size=0.25)
-    #ann3_train, ann3_val = train_test_split(ann3_train, stratify=ann3_train[features_strat],random_state=RSEED, test_size=0.13)
+    df_train = pd.concat([ann2_train, df_ann3_feedback_stories], axis=0)
 
-    ann2_train.id_post.to_csv('./data/ann2_train.csv', header=False)
+    print(f"Number of posts in train-set: {df_train.shape[0]}")
+    print(f"Number of posts in val-set: {ann2_val.shape[0]}")
+    print(f"Number of posts in test-set: {ann2_test.shape[0]}")
+    df_train.id_post.to_csv('./data/ann2_train.csv', header=False)
     ann2_test.id_post.to_csv('./data/ann2_test.csv', header=False)
     ann2_val.id_post.to_csv('./data/ann2_val.csv', header=False)
-
-    #ann3_train.id_post.to_csv('./data/ann3_train.csv', header=False)
-    #ann3_test.id_post.to_csv('./data/ann3_test.csv', header=False)
-    #ann3_val.id_post.to_csv('./data/ann3_val.csv', header=False)
-
     print('Splits created.')
+
 
 if __name__ == '__main__':
     create_splits()


### PR DESCRIPTION
utils.train_test_val_split:
- Posts annotated in round 2 should represent the population and can be
  used for validation and test set.
- Stratify by labels that are rare in annotation round 2.
- Use annotations for personal stories and possibly feedback to get
  better balance for these labels in training data.

utils.loading function load_extended_posts:
- Include parameter "label" to get only posts with annotations for that label.